### PR TITLE
fix: dynamically adjust position of reload and add member buttons to keep them in page

### DIFF
--- a/src/pages/AdminTeam.tsx
+++ b/src/pages/AdminTeam.tsx
@@ -220,18 +220,34 @@ const AdminTeam = () => {
     <>
       <Container maxWidth="lg" sx={{ py: 4 }}>
         <Paper elevation={3} sx={{ p: 4 }}>
-          <Box sx={{ display: 'flex', alignItems: 'center', mb: 4, gap: 2 }}>
-            <TeamIcon sx={{ fontSize: 40, color: '#e86161' }} />
-            <Box sx={{ flex: 1 }}>
-              <Typography
-                variant="h4"
-                sx={{ color: '#e86161', fontWeight: 700 }}
-              >
-                Team Member Management
-              </Typography>
-              <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-                Manage team members displayed on the team page
-              </Typography>
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: { xs: 'column', sm: 'row' },
+              alignItems: { xs: 'flex-start', sm: 'center' },
+              mb: 4,
+              gap: 2,
+            }}
+          >
+            <Box
+              sx={{ display: 'flex', alignItems: 'center', gap: 2, flex: 1 }}
+            >
+              <TeamIcon sx={{ fontSize: 40, color: '#e86161' }} />
+              <Box>
+                <Typography
+                  variant="h4"
+                  sx={{
+                    color: '#e86161',
+                    fontWeight: 700,
+                    fontSize: { xs: '1.5rem', sm: '2.125rem' },
+                  }}
+                >
+                  Team Member Management
+                </Typography>
+                <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                  Manage team members displayed on the team page
+                </Typography>
+              </Box>
             </Box>
             <Box sx={{ display: 'flex', gap: 1 }}>
               <Button


### PR DESCRIPTION
The mentioned buttons are dynamically changes position to under text based on web page resolution. Should fix them going out of page bounds.